### PR TITLE
compile on latest MSVC

### DIFF
--- a/mingw-w64-headers/include/gdiplus/gdiplusinit.h
+++ b/mingw-w64-headers/include/gdiplus/gdiplusinit.h
@@ -43,8 +43,8 @@ typedef struct GdiplusStartupInput {
 	#endif /* __cplusplus */
 } GdiplusStartupInput;
 
-typedef GpStatus WINGDIPAPI (*NotificationHookProc)(ULONG_PTR *token);
-typedef VOID WINGDIPAPI (*NotificationUnhookProc)(ULONG_PTR token);
+typedef GpStatus (WINGDIPAPI *NotificationHookProc)(ULONG_PTR *token);
+typedef VOID (WINGDIPAPI *NotificationUnhookProc)(ULONG_PTR token);
 
 typedef struct GdiplusStartupOutput {
 	NotificationHookProc NotificationHook;

--- a/mingw-w64-headers/include/gdiplus/gdiplustypes.h
+++ b/mingw-w64-headers/include/gdiplus/gdiplustypes.h
@@ -450,9 +450,8 @@ private:
 } PathData;
 
 /* Callback function types */
-/* FIXME: need a correct definition for these function pointer types */
 typedef void *DebugEventProc;
-typedef BOOL CALLBACK (*EnumerateMetafileProc)(EmfPlusRecordType,UINT,UINT,const BYTE*,VOID*);
+typedef BOOL (CALLBACK *EnumerateMetafileProc)(EmfPlusRecordType,UINT,UINT,const BYTE*,VOID*);
 typedef void *DrawImageAbort;
 typedef void *GetThumbnailImageAbort;
 


### PR DESCRIPTION
Hello

Please consider this minor patch that allows gdi+ headers to be compiled by the latest (and probably all, I only tried it on the latest) MSVC compiler. The reason is that for my project I need pure C-based GDI+, which cl.exe cannot do, it insists on compiling in C++ mode, so I shamelessly copied the gdiplus headers from mingw-w64 project. It seems that cl.exe also cannot compile

```typedef A __cdecl (*func)(...)```

but 

```typedef A (__cdecl *func)(...)```

works fine. GCC compiles this without problem too. 

In the patch I removed the FIXME comment, to my best understanding that comment was exactly about this syntax.

Thank you all for great project!
Regards,
Dmitry