### PR TITLE
Fix reference counting bug in Microsoft::WRL::ComPtr::Attach

### DIFF
--- a/mingw-w64-headers/include/wrl/client.h
+++ b/mingw-w64-headers/include/wrl/client.h
@@ -206,7 +206,6 @@ namespace Microsoft {
                 if (ptr_ != other) {
                     InternalRelease();
                     ptr_ = other;
-                    InternalAddRef();
                 }
             }
 


### PR DESCRIPTION
Microsoft::WRL::ComPtr::Attach should take ownership of an interface and must therefore not increment the reference count of the attached interface pointer.

This patch fixes this issue, and makes the MINGW64 implementation behave the same way as the implementation shipped with the Microsoft SDK.

Fixes: [#892 Microsoft::WRL::ComPtr::Attach leaks references](https://sourceforge.net/p/mingw-w64/bugs/892/)