### PR TITLE
Include pthread_compat.h in sched.h for pid_t

### DIFF
--- a/mingw-w64-libraries/winpthreads/include/sched.h
+++ b/mingw-w64-libraries/winpthreads/include/sched.h
@@ -30,6 +30,8 @@
 
 #include <sys/timeb.h>
 
+#include "pthread_compat.h"
+
 #ifndef WIN_PTHREADS_SCHED_H
 #define WIN_PTHREADS_SCHED_H
 


### PR DESCRIPTION
`pid_t` is not there in MSVC