### PR TITLE
Implement safe stdio flush at exit

### DIFF
--- a/mingw-w64-crt/crt/crtexe.c
+++ b/mingw-w64-crt/crt/crtexe.c
@@ -76,6 +76,12 @@ __mingw_invalidParameterHandler (const wchar_t * __UNUSED_PARAM_1(expression),
 #endif
 }
 
+static void
+__mingw_safeStdioFlush (void)
+{
+  fflush (NULL);
+}
+
 static int __tmainCRTStartup (void);
 
 int WinMainCRTStartup (void);
@@ -150,6 +156,10 @@ __tmainCRTStartup (void)
     BOOL nested = FALSE;
     _startupinfo startinfo;
     int ret = 0;
+
+    if (atexit (__mingw_safeStdioFlush) != 0)
+      return 255;
+
     while((lock_free = InterlockedCompareExchangePointer (&__native_startup_lock,
 							  fiberid, NULL)) != 0)
       {


### PR DESCRIPTION
The Windows CRT flushes all stdio streams open for output within its DllMain handler. This is not quite safe:

1. A DLL may acquire locks on process termination, which can cause instant termination.
2. The flushing operation itself must acquire locks, and that goes against the rules for DllMain on process termination.

This commit adds an atexit handler that flushes all output streams before ExitProcess is called. This also helps in UWP execution environments where ExitProcess behaves like TerminateProcess.

### References:

1. https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-best-practices
2. https://devblogs.microsoft.com/oldnewthing/20100122-00/?p=15193