### PR TITLE
Ensure that stderr is not fully buffered

### DIFF
--- a/mingw-w64-crt/crt/crtexe.c
+++ b/mingw-w64-crt/crt/crtexe.c
@@ -199,6 +199,18 @@ __tmainCRTStartup (void)
 	if (__globallocalestatus == -1)
 	  _configthreadlocale (-1);
 
+#if !defined (_UCRT)
+	/* Before the UCRT stderr could be opened in full buffering
+	* mode, for example when output goes to a pipe).
+	*
+	* Recent C standard disallow full buffering on stderr.
+	* Note that line buffering is the same as full buffering
+	* in the Windows CRT, so we have to disable buffering
+	* altogether.
+	*/
+	setvbuf (stderr, NULL, _IONBF, 0);
+#endif
+
 	if (_initterm_e (__xi_a, __xi_z) != 0)
 	  return 255;
 


### PR DESCRIPTION
CRT libraries before the UCRT can open stderr in full-buffering mode. For example when output goes to a pipe.

The C standard disallow such mode on stderr: _"as initially opened, the standard error stream is not fully buffered"_ ([C23 7.23.2 pt. 7](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf#subsection.7.23.3)). Here we ensure that stderr is unbuffered.

We can't use line buffering because it's the same as full buffering: ([link](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setvbuf?view=msvc-170))

> _IOLBF: For some systems this mode provides line buffering. However on Win32 the behavior is the same as _IOFBF - Full Buffering.

However I don't know if we want to change things now that the UCRT is widely adopted